### PR TITLE
Fix TypeError in hash_key calculation

### DIFF
--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -76,7 +76,8 @@ class DrawIO(SphinxDirective):
 def render_drawio(self: SphinxTranslator, node: DrawIONode, in_filename: str,
                   output_format: str) -> str:
     """Render drawio file into an output image file."""
-    hash_key = "".join(node.attlist()).encode()
+    node_attr = dict((y, x) for x, y in node.attlist())
+    hash_key = "".join(node_attr).encode()
     filename = "drawio-{}.{}".format(sha1(hash_key).hexdigest(),
                                      output_format)
     file_path = posixpath.join(self.builder.imgpath, filename)


### PR DESCRIPTION
This PR aims to fix two things:

* Since 2fb93aa3cf56092ef19ddce5a09e29c5d4b29896, the plugin fails with:
```
  File "~/.local/lib/python3.6/site-packages/sphinxcontrib/drawio.py", line 79, in render_drawio
    hash_key = "".join(node.attlist()).encode()
TypeError: sequence item 0: expected str instance, tuple found
```

* IMHO there was an error in the `hash_key` calculation because it was containing the concatenation of the keys of the dict, not the values.