### PR TITLE
Make drawio_headless False by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 sphinxcontrib_drawio.egg-info/
 
 venv/
+
+# Local user config for tests
+tests/local_user_config.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sphinx Extension to add the ``drawio`` directive to include draw.io diagrams.
 The drawio-desktop package does not run without an x-server (e.g. when in a CI
 environment), see
 [this issue](https://github.com/jgraph/drawio-desktop/issues/146).
-The workaround is to install `xvfb-run`.
+The workaround is to install `xvfb-run` and set the `drawio_headless` config to `True`.
 
 ## Installation
 
@@ -25,9 +25,9 @@ Linux add `/opt/draw.io/`.
 These are the available options and their default values.
 
 ```python
-drawio_output_format = "png"
+drawio_output_format = "png" # from ["png", "jpg", "svg"]
 drawio_binary_path = "/path/to/draw.io-binary"
-drawio_headless = True
+drawio_headless = False
 ```
 
 ## Usage

--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -184,7 +184,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_directive("drawio", DrawIO)
     app.add_config_value("drawio_output_format", "png", "html")
     app.add_config_value("drawio_binary_path", None, "html")
-    app.add_config_value("drawio_headless", True, "html")
+    app.add_config_value("drawio_headless", False, "html")
 
     # Add CSS file to the HTML static path for add_css_file
     app.connect("build-finished", on_build_finished)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,62 @@
+import json
+import os
+from pathlib import Path
+
 import pytest
 from bs4 import BeautifulSoup
+from sphinx.application import Sphinx
 
 from sphinx.testing.path import path
 
 pytest_plugins = "sphinx.testing.fixtures"
+
+
+def _set_config_options_from_json(app: Sphinx, config: dict) -> None:
+    for key, value in config.items():
+        app.config[key] = value
+
+
+def _set_config_options_from_json_path(app: Sphinx, config_path: str) -> None:
+    """Adds extra sphinx conf.py values from a JSON file
+
+    Equivalent to a conf.py inside the test root directory. Useful for
+    having global config options between tests.
+
+    Example:
+    {
+      "exclude_patterns": ["_build"],
+      "drawio_headless": false
+    }
+
+    Modified from code by @yamionp
+    """
+
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+            _set_config_options_from_json(app, config)
+
+    except FileNotFoundError:
+        pass
+
+
+def _setup_local_user_config(app):
+    """Sets the local user's conf.py values for all tests
+
+    Useful for when a developer needs to configure values for a device-specific
+    change. The file is .gitignore'd so it will not appear in git.
+    Stored in tests/local_user_config.json"""
+    local_user_conf_path = Path(__file__).parent.absolute() / "local_user_config.json"
+    _set_config_options_from_json_path(app, local_user_conf_path)
+
+
+def _setup_headless_mode_on_ci(app):
+    """Enables drawio_headless=True when used in the CI environment
+
+    Relies on the circleCI `CI` environment variable
+    """
+    if os.getenv("CI", False):
+        _set_config_options_from_json(app, {"drawio_headless": True})
 
 
 @pytest.fixture(scope="session")
@@ -12,14 +65,16 @@ def rootdir():
 
 
 @pytest.fixture()
-def content(app):
+def content(app: Sphinx):
+    _setup_local_user_config(app)
+    _setup_headless_mode_on_ci(app)
     app.build()
     yield app
 
 
 @pytest.fixture()
-def page(content, request) -> BeautifulSoup:
-    pagename = request.param
-    c = (content.outdir / pagename).text()
+def page(content: Sphinx, request) -> BeautifulSoup:
+    page_name = request.param
+    c = (content.outdir / page_name).text()
 
     yield BeautifulSoup(c, "html.parser")


### PR DESCRIPTION
Tests now autodetect if on CI and enable it if so.

Closes #5 