### PR TITLE
Rework how headless mode is implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ extensions = [
 ```
 3. Add the binary to `$PATH`. For Windows add `C:\Program Files\draw.io` and on
 Linux add `/opt/draw.io/`. 
+4. (if running headless), `sudo apt install xvfb`
 
 ## Options
 These values are placed in the `conf.py` of your sphinx project.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Sphinx Extension to add the ``drawio`` directive to include draw.io diagrams.
 The drawio-desktop package does not run without an x-server (e.g. when in a CI
 environment), see
 [this issue](https://github.com/jgraph/drawio-desktop/issues/146).
-The workaround is to install `xvfb-run` and set the `drawio_headless` config to `True`.
+The workaround is to install `xvfb` and set the `drawio_headless` config to `auto`.
+
+If any other of the `draw.io` CLI tool's options are wanted, please file an issue.
 
 ## Installation
 
@@ -19,23 +21,89 @@ extensions = [
 ```
 3. Add the binary to `$PATH`. For Windows add `C:\Program Files\draw.io` and on
 Linux add `/opt/draw.io/`. 
-4. (required for `drawio_headless`) `sudo apt install xvfb`
 
 ## Options
-These are the available options and their default values.
+These values are placed in the `conf.py` of your sphinx project.
 
-```python
-drawio_output_format = "png" # from ["png", "jpg", "svg"]
-drawio_binary_path = "/path/to/draw.io-binary"
-drawio_headless = False
-```
+### Output Format
+- *Formal Name*: `drawio_output_format`
+- *Default Value*: `"png"`
+- *Possible Values*: `"png"`, `"jpg"`, or `"svg"`
+
+This config option controls the output file format which will be placed inside
+the generated HTML. More file formats are available but not exposed, please
+file an issue if you wish to add another file format.
+
+### Binary Path
+- *Formal Name*: `drawio_binary_path`
+- *Default Value*: `None`
+
+This allows for a specific override for the binary location. By default, this
+gets chosen depending on the OS (Linux, Mac, or Windows) to the default
+install path of the draw.io program.
+
+### Headless Mode
+- *Formal Name*: `drawio_headless`
+- *Default Value*: `"auto"`
+- *Possible Values*: `True`, `False`, or `"auto"`
+
+This config option controls the behaviour of running the Xvfb server. It is
+necessary because `draw.io` will not work without an X-server, see
+[this issue](https://github.com/jgraph/drawio-desktop/issues/146).
+
+The `auto` mode (on unix-like systems) will detect whether the program is
+running in a headless environment through the `$DISPLAY` environment variable,
+and act as if it were set to `True`. If running on Windows, or the `$DISPLAY`
+environment variable contains some value (i.e. run in an X-server on a
+developer's machine).
+
+Setting the value to `True` will start a virtual X framebuffer through the
+`Xvfb` command before running any `draw.io` commands, and stop it afterwards.
+
+Setting the value to `False` will run the `draw.io` binary as normal.
 
 ## Usage
+The extension can be used through the `drawio` directive, as per below:
 ```
 .. drawio:: example.drawio
-    :format: png
-    :alt: An Example
-    :align: center
-    :page-index: 0
 ```
-If any other of the `draw.io` CLI tool's options are wanted, please file an issue.
+
+The directive can also be configured with a variety of options.
+
+### Format
+- *Formal Name*: `:format:`
+- *Default Value*: `"png"`
+- *Possible Values*: `"png"`, `"jpg"`, or `"svg"`
+
+This option controls the output file format of *this specific* directive. It
+provides similar functionality to that of the `drawio_output_format` config
+option but at a more granular level.
+
+### Alt Text
+- *Formal Name*: `:alt:`
+
+This option sets the img tag's `alt` attribute. For more information on its
+functionality, see [the Mozilla web documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-alt).
+
+### Format
+- *Formal Name*: `:format:`
+- *Default Value*: `"png"`
+- *Possible Values*: `"png"`, `"jpg"`, or `"svg"`
+
+This option controls the output file format of *this specific* directive. It
+provides similar functionality to that of the `drawio_output_format` config
+option but at a more granular level.
+
+### Alignment
+- *Formal Name*: `:align:`
+- *Possible Values*: `"left"`, `"center"`, or `"right"`
+
+This option allows control over the alignment of the image on the page.
+
+### Page Index
+- *Formal Name*: `:page-index:`
+- *Default Value*: `0`
+- *Possible Values*: any integer
+
+This option allows you to select a particular page from a draw.io file to
+create the image from.

--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -24,8 +24,8 @@ X_DISPLAY_NUMBER = 1
 
 def is_headless(config: Config):
     if config.drawio_headless == "auto":
-        if platform.system() == "Windows":
-            # Xvfb can never run on windows
+        if platform.system() != "Linux":
+            # Xvfb can only run on Linux
             return False
 
         # DISPLAY will exist if an X-server is running.

--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -23,8 +23,11 @@ X_DISPLAY_NUMBER = 1
 
 
 def is_headless(config: Config):
-    if isinstance(config.drawio_headless, str) \
-            and config.drawio_headless.lower() == "auto":
+    if config.drawio_headless == "auto":
+        if platform.system() == "Windows":
+            # Xvfb can never run on windows
+            return False
+
         # DISPLAY will exist if an X-server is running.
         if os.getenv("DISPLAY"):
             return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,20 +42,13 @@ def _set_config_options_from_json_path(app: Sphinx, config_path: str) -> None:
 def _setup_local_user_config(app):
     """Sets the local user's conf.py values for all tests
 
+    **Note**: This will not work for the `drawio_headless` config option.
+
     Useful for when a developer needs to configure values for a device-specific
     change. The file is .gitignore'd so it will not appear in git.
     Stored in tests/local_user_config.json"""
     local_user_conf_path = Path(__file__).parent.absolute() / "local_user_config.json"
     _set_config_options_from_json_path(app, local_user_conf_path)
-
-
-def _setup_headless_mode_on_ci(app):
-    """Enables drawio_headless=True when used in the CI environment
-
-    Relies on the circleCI `CI` environment variable
-    """
-    if os.getenv("CI", False):
-        _set_config_options_from_json(app, {"drawio_headless": True})
 
 
 @pytest.fixture(scope="session")
@@ -66,7 +59,6 @@ def rootdir():
 @pytest.fixture()
 def content(app: Sphinx):
     _setup_local_user_config(app)
-    _setup_headless_mode_on_ci(app)
     app.build()
     yield app
 


### PR DESCRIPTION
`Xvfb` is now run once at the start and used for later runs of `draw-io`, rather than a new display being created every time.

README.md has also been massively improved and documented for this option and other configs.