### PR TITLE
Perform export only when the input file changes

### DIFF
--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -1,6 +1,8 @@
+import os
 import os.path
 import platform
 import posixpath
+import signal
 import subprocess
 from hashlib import sha1
 from os.path import getmtime
@@ -282,13 +284,8 @@ def on_build_finished(app: Sphinx, exc: Exception) -> None:
         copy_asset(src, dst)
 
     if is_headless(app.builder.config):
-        try:
-            subprocess.run(["kill", str(app.builder.config.xvfb_pid)],
-                           stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                           check=True)
-        except subprocess.CalledProcessError as exc:
-            logger.warning("Failed to kill Xvfb:n[stderr]\n{}"
-                           "\n[stdout]\n{}".format(exc.stderr, exc.stdout))
+        os.kill(app.builder.config.xvfb_pid, signal.SIGTERM)
+        os.waitid(os.P_PID, app.builder.config.xvfb_pid, os.WEXITED)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,16 @@ def content(app: Sphinx):
     app.build()
     yield app
 
+    
+@pytest.fixture()
+def make_app_with_local_user_config(make_app):
+    def make(*args, **kwargs):
+        app = make_app(*args, **kwargs)
+        _setup_local_user_config(app)
+        return app
+
+    yield make
+
 
 def _directives(content: Sphinx) -> List[Tag]:
     c = (content.outdir / "index.html").text()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+from sphinx.application import Sphinx
+
+
+SIMPLE_EXPORTED_FNAME = "drawio-bf0f85b68784bab0e62bf5902f5a46b65d71ee70.png"
+
+
+@pytest.mark.sphinx("html", testroot="simple")
+def test_notchanged(content: Sphinx, make_app_with_local_user_config):
+    exported = content.outdir / "_images" / SIMPLE_EXPORTED_FNAME
+    exported_timestamp = exported.stat().st_mtime
+    app = make_app_with_local_user_config(srcdir=content.srcdir)
+    app.build()
+    assert exported.stat().st_mtime == exported_timestamp
+
+
+@pytest.mark.sphinx("html", testroot="simple")
+def test_changed(content: Sphinx, make_app_with_local_user_config):
+    source = Path(content.srcdir / "box.drawio")
+    exported = content.outdir / "_images" / SIMPLE_EXPORTED_FNAME
+    exported_timestamp = exported.stat().st_mtime
+    source.touch()
+    app = make_app_with_local_user_config(srcdir=content.srcdir)
+    app.build()
+    assert exported.stat().st_mtime > exported_timestamp


### PR DESCRIPTION
Before, changes to the drawio file would be ignored when it had
previously been exported. Now, the output file is overwritten when the
input file has a newer timestamp.