### PR TITLE
Switch over to setup.cfg from setup.py and static versioning

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-name="sphinxcontrib-drawio"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = sphinxcontrib_drawio
+version = attr: sphinxcontrib.__version__
+author = Modelmat
+author_email = modelmat@outlook.com.au
+description = Sphinx Extension to include draw.io files
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/Modelmat/sphinxcontrib-drawio
+license = MIT
+classifier =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Framework :: Sphinx :: Extension
+
+[options]
+packages = sphinxcontrib
+python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,5 @@
-import subprocess
-
 import setuptools
 
-# This will fail if something happens or if not in a git repository.
-# This is intentional.
-ret = subprocess.run("git describe --tags --abbrev=0", stdout=subprocess.PIPE,
-                     stderr=subprocess.PIPE, check=True, shell=True)
-version = ret.stdout.decode("utf-8").strip()
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
 setuptools.setup(
-    name="sphinxcontrib-drawio",
-    version=version,
-    author="Modelmat",
-    author_email="modelmat@outlook.com.au",
-    description="Sphinx Extension to include draw.io files",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/Modelmat/sphinxcontrib-drawio",
-    packages=['sphinxcontrib'],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Framework :: Sphinx :: Extension",
-    ],
-    python_requires='>=3.6',
+    # see setup.cfg
 )

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,0 +1,2 @@
+name="sphinxcontrib-drawio"
+__version__="0.10.0"

--- a/sphinxcontrib/drawio.py
+++ b/sphinxcontrib/drawio.py
@@ -19,6 +19,7 @@ from sphinx.util import logging, ensuredir
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.fileutil import copy_asset
 
+from . import __version__
 from .old_drawio import (DrawIONode, DrawIO,
                          render_drawio_html, render_drawio_latex)
 
@@ -293,4 +294,4 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.connect("config-inited", on_config_inited)
     app.add_css_file("drawio.css")
 
-    return {"parallel_read_safe": True}
+    return {"version": __version__, "parallel_read_safe": True}


### PR DESCRIPTION
This removes the need to manually fetch file contents and is
instead handled by setuptools natively.

This also serves as the base for a change to static versioning,
which allows us to :
* build without a git repository
* allows sphinx extension setup() to return a version
* have a commit specifically for upping the package version
  and for tagging