### PR TITLE
Update dependencies for tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,7 +44,11 @@ jobs:
           pip install -r dev-requirements.txt
       - name: Intall draw.io dependencies
         run: |
-          wget -O drawio.deb https://github.com/jgraph/drawio-desktop/releases/download/v12.6.5/draw.io-amd64-12.6.5.deb
+          curl -s https://api.github.com/repos/jgraph/drawio-desktop/releases/latest \
+                    | grep "browser_download_url.*deb" \
+                    | cut -d : -f 2,3 \
+                    | tr -d \" \
+                    | wget -qi - -O drawio.deb
           sudo apt install xvfb ./drawio.deb
       - name: Install Package
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7',  '3.8']
+        python-version: ['3.6', '3.7',  '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Update tests to use Python 3.9.
Also, run on the latest draw.io deb. 