### PR TITLE
Add returncode to subprocess.CalledProcessError output

### DIFF
--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -269,7 +269,7 @@ class DrawIOConverter(ImageConverter):
         except subprocess.CalledProcessError as exc:
             raise DrawIOError(
                 "draw.io ({}) exited with error:\n[stderr]\n{}"
-                "\n[stdout]\n{}".format(" ".join(drawio_args), exc.stderr, exc.stdout)
+                "\n[stdout]\n{}\n[returncode]\n{}".format(" ".join(drawio_args), exc.stderr, exc.stdout, exc.returncode)
             )
         if not export_abspath.exists():
             raise DrawIOError(

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -269,7 +269,9 @@ class DrawIOConverter(ImageConverter):
         except subprocess.CalledProcessError as exc:
             raise DrawIOError(
                 "draw.io ({}) exited with error:\n[stderr]\n{}"
-                "\n[stdout]\n{}\n[returncode]\n{}".format(" ".join(drawio_args), exc.stderr, exc.stdout, exc.returncode)
+                "\n[stdout]\n{}\n[returncode]\n{}".format(
+                    " ".join(drawio_args), exc.stderr, exc.stdout, exc.returncode
+                )
             )
         if not export_abspath.exists():
             raise DrawIOError(


### PR DESCRIPTION
This is for slightly better output as discussed in https://github.com/modelmat/sphinxcontrib-drawio/issues/69. It appears not all return codes have `stderr` output associated with them, so this will help in those rare cases.

Apparently there are ways to get more information about the return code, such as this line in [subprocess.py](https://github.com/python/cpython/blob/cb35402c1867b48704c2de1d1efd465ca738f374/Lib/subprocess.py#L132), but I didn't know how finicky that would be and I left it as the bare return code.

Fixes #69 