### PR TITLE
Improve drawio binary finding functionality to use $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ issue.
 ## Installation
 
 1. `python3 -m pip install sphinxcontrib-drawio`
-2. In your sphinx config:
+2. In your sphinx config, add:
 
     ```python
     extensions = [
@@ -50,9 +50,10 @@ issue.
     ]
     ```
 
-3. Add the binary to `$PATH`. For Windows add `C:\Program Files\draw.io` and on
-Linux add `/opt/drawio/`. 
-4. (if running headless), `sudo apt install xvfb`
+3. Add the draw.io binary to `$PATH`. See [Options: Binary Path](#binary-path)
+   for more details and alternative solutions.
+
+4. If running headless, install Xvfb, e.g. via `$ sudo apt install xvfb`.
 
 ## Options
 These values are placed in the `conf.py` of your sphinx project.
@@ -62,8 +63,12 @@ These values are placed in the `conf.py` of your sphinx project.
 - *Default Value*: `None`
 
 This allows for a specific override for the binary location. By default, this
-gets chosen depending on the OS (Linux, Mac, or Windows) to the default
-install path of the draw.io program.
+chooses the `drawio` (or `draw.io.exe`) binary accessible in `$PATH`. However,
+if this file does not exist, it picks the platform-appropriate path:
+
+- Windows: `C:\Program Files\draw.io\draw.io.exe`
+- Linux: `/opt/drawio/drawio` or `/opt/draw.io/drawio` (older versions)
+- MacOS: `/Applications/draw.io.app/Contents/MacOS/draw.io`.
 
 ### Headless Mode
 - *Formal Name*: `drawio_headless`

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import platform
+import shutil
 import subprocess
 from hashlib import sha1
 from pathlib import Path
@@ -205,14 +206,29 @@ class DrawIOConverter(ImageConverter):
         ):
             return export_abspath
 
+        drawio_in_path = shutil.which("drawio")
+        draw_dot_io_in_path = shutil.which("draw.io")
+        WINDOWS_PATH = r"C:\Program Files\draw.io\draw.io.exe"
+        MACOS_PATH = "/Applications/draw.io.app/Contents/MacOS/draw.io"
+        LINUX_PATH = "/opt/drawio/drawio"
+        LINUX_OLD_PATH = "/opt/draw.io/drawio"
+
         if builder.config.drawio_binary_path:
             binary_path = builder.config.drawio_binary_path
-        elif platform.system() == "Windows":
-            binary_path = r"C:\Program Files\draw.io\draw.io.exe"
+        elif drawio_in_path:
+            binary_path = drawio_in_path
+        elif draw_dot_io_in_path:
+            binary_path = draw_dot_io_in_path
+        elif platform.system() == "Windows" and os.path.isfile(WINDOWS_PATH):
+            binary_path = WINDOWS_PATH
+        elif platform.system() == "Darwin" and os.path.isfile(MACOS_PATH):
+            binary_path = MACOS_PATH
+        elif platform.system() == "Linux" and os.path.isfile(LINUX_PATH):
+            binary_path = LINUX_PATH
+        elif platform.system() == "Linux" and os.path.isfile(LINUX_OLD_PATH):
+            binary_path = LINUX_OLD_PATH
         else:
-            binary_path = "/opt/drawio/drawio"
-            if not os.path.isfile(binary_path):
-                binary_path = "/opt/draw.io/drawio"
+            raise DrawIOError("No drawio executable found")
 
         scale_args = ["--scale", scale]
         if output_format == "pdf" and float(scale) == 1.0:


### PR DESCRIPTION
Fixes #23, #24 and #66.

Prioritises config-option binary_path, then programs in $PATH,
then the hardcoded absolute paths. Also raises an error if
cannot find the executable as opposed to just attempting to run
draw.io as a Linux program anyway.