### PR TITLE
Add drawio_disable_verbose_electron option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ This will be overridden if the transparency is set for a individual diagram in
 the directive. If the output format isn't *png*, it will not affect the image
 exported.
 
-### Enable Logging
-- *Formal Name*: `drawio_enable_logging`
-- *Default Value*: `False`
+### Enable Verbrose Electron
+- *Formal Name*: `drawio_enable_verbrose_electron`
+- *Default Value*: `True`
 - *Possible Values*: `True` or `False`
 
-This option may be needed to help troubleshoot certain errors produced by the drawio app. See the
+This option may be needed to help troubleshoot certain errors produced by the
+drawio app. This option only affects the output when the drawio app errors. See the
 [Electron docs](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile)
 for more info.
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,14 @@ This will be overridden if the transparency is set for a individual diagram in
 the directive. If the output format isn't *png*, it will not affect the image
 exported.
 
-### Enable Verbrose Electron
-- *Formal Name*: `drawio_enable_verbrose_electron`
-- *Default Value*: `True`
+### Disable Verbose Electron
+- *Formal Name*: `drawio_disable_verbose_electron`
+- *Default Value*: `False`
 - *Possible Values*: `True` or `False`
 
-This option may be needed to help troubleshoot certain errors produced by the
-drawio app. This option only affects the output when the drawio app errors. See the
+Electron's verbose logging is turned on by default to help troubleshoot certain
+errors produced by the drawio app, but can be disabled if it causes a logging
+conflict. This option only affects the output when the drawio app errors. See the
 [Electron docs](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile)
 for more info.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ This will be overridden if the transparency is set for a individual diagram in
 the directive. If the output format isn't *png*, it will not affect the image
 exported.
 
+### Enable Logging
+- *Formal Name*: `drawio_enable_logging`
+- *Default Value*: `False`
+- *Possible Values*: `True` or `False`
+
+This option may be needed to help troubleshoot certain errors produced by the drawio app. See the
+[Electron docs](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile)
+for more info.
+
 ### No Sandbox
 - *Formal Name*: `drawio_no_sandbox`
 - *Default Value*: `False`

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -180,7 +180,7 @@ class DrawIOConverter(ImageConverter):
         transparent = options.get(
             "transparency", builder.config.drawio_default_transparency
         )
-        enable_verbrose_electron = builder.config.drawio_enable_verbrose_electron
+        disable_verbose_electron = builder.config.drawio_disable_verbose_electron
         no_sandbox = builder.config.drawio_no_sandbox
 
         # Any directive options which would change the output file would go here
@@ -246,7 +246,7 @@ class DrawIOConverter(ImageConverter):
             str(input_abspath),
         ]
 
-        if enable_verbrose_electron:
+        if not disable_verbose_electron:
             drawio_args.append("--enable-logging")
 
         if no_sandbox:
@@ -346,7 +346,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("drawio_headless", "auto", "html", ENUM("auto", True, False))
     # noinspection PyTypeChecker
     app.add_config_value(
-        "drawio_enable_verbrose_electron", True, "html", ENUM(True, False)
+        "drawio_disable_verbose_electron", False, "html", ENUM(True, False)
     )
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -345,7 +345,9 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # noinspection PyTypeChecker
     app.add_config_value("drawio_headless", "auto", "html", ENUM("auto", True, False))
     # noinspection PyTypeChecker
-    app.add_config_value("drawio_enable_verbrose_electron", True, "html", ENUM(True, False))
+    app.add_config_value(
+        "drawio_enable_verbrose_electron", True, "html", ENUM(True, False)
+    )
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 
     # deprecated

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -180,7 +180,7 @@ class DrawIOConverter(ImageConverter):
         transparent = options.get(
             "transparency", builder.config.drawio_default_transparency
         )
-        enable_logging = builder.config.drawio_enable_logging
+        enable_verbrose_electron = builder.config.drawio_enable_verbrose_electron
         no_sandbox = builder.config.drawio_no_sandbox
 
         # Any directive options which would change the output file would go here
@@ -246,7 +246,7 @@ class DrawIOConverter(ImageConverter):
             str(input_abspath),
         ]
 
-        if enable_logging:
+        if enable_verbrose_electron:
             drawio_args.append("--enable-logging")
 
         if no_sandbox:
@@ -345,7 +345,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # noinspection PyTypeChecker
     app.add_config_value("drawio_headless", "auto", "html", ENUM("auto", True, False))
     # noinspection PyTypeChecker
-    app.add_config_value("drawio_enable_logging", False, "html", ENUM(True, False))
+    app.add_config_value("drawio_enable_verbrose_electron", True, "html", ENUM(True, False))
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 
     # deprecated

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -180,6 +180,7 @@ class DrawIOConverter(ImageConverter):
         transparent = options.get(
             "transparency", builder.config.drawio_default_transparency
         )
+        enable_logging = builder.config.drawio_enable_logging
         no_sandbox = builder.config.drawio_no_sandbox
 
         # Any directive options which would change the output file would go here
@@ -244,6 +245,9 @@ class DrawIOConverter(ImageConverter):
             str(export_abspath),
             str(input_abspath),
         ]
+
+        if enable_logging:
+            drawio_args.append("--enable-logging")
 
         if no_sandbox:
             # This may be needed for docker support, and it has to be the last argument to work.
@@ -341,6 +345,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # noinspection PyTypeChecker
     app.add_config_value("drawio_headless", "auto", "html", ENUM("auto", True, False))
     # noinspection PyTypeChecker
+    app.add_config_value("drawio_enable_logging", False, "html", ENUM(True, False))
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 
     # deprecated


### PR DESCRIPTION
I figured out you can add the Electron CLI [--enable-logging](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile) option to get more information.  For example this is the `[stderr]` output with logging on:

```
[stderr]
b'[3243:0511/224439.493686:ERROR:bus.cc(393)] Failed to connect to the bus: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory\n[3243:0511/224440.148733:ERROR:bus.cc(393)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")\n[3243:0511/224440.338936:ERROR:bus.cc(393)] Failed to connect to the bus: Could not parse server address: Unknown address type (examples of valid types are "tcp" and on UNIX "unix")\n[3243:0511/224440.340409:ERROR:block_files.cc(466)] Failed to open /home/user/.config/draw.io/GPUCache/data_0\n[3243:0511/224440.505328:ERROR:gpu_process_host.cc(1003)] GPU process exited unexpectedly: exit_code=134\n[3243:0511/224440.505359:WARNING:gpu_process_host.cc(1317)] The GPU process has crashed 1 time(s)\n[3243:0511/224440.688088:ERROR:gpu_process_host.cc(1003)] GPU process exited unexpectedly: exit_code=134\n[3243:0511/224440.688113:WARNING:gpu_process_host.cc(1317)] The GPU process has crashed 2 time(s)\n'
[stdout]
b''
[returncode]
-7
```

If there aren't any errors, then the output of the extension is unchanged. This output was helpful in figuring out more information about the problems Electron was having, as outlined [in this comment](https://github.com/cypress-io/cypress/blob/770b96222d38726f5c70b8864e12264b186babfa/cli/lib/exec/spawn.js#L19-L30). I don't know if `enable_logging` should just always be on and not even an option, or the default should be `True`, but I left the default behavior as-is to be conservative.

Note: I'm working a potential similar "fix" that they implemented (so another PR in the works), that will allow the user to specify a list of strings to check for in the `[stderr]`. If there is a match, the exception passes so that in cases like this where nothing can be done to fix the issue, and the issue isn't really causing any problems, you can keep your CI from failing.