### PR TITLE
Rework conversion handling to prevent subtle errors

### DIFF
--- a/tests/roots/test-bad-config2/conf.py
+++ b/tests/roots/test-bad-config2/conf.py
@@ -1,0 +1,9 @@
+extensions = ["sphinxcontrib.drawio"]
+
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+# removes most of the HTML
+html_theme = "basic"
+
+drawio_builder_export_format = {"html": "pdf"}

--- a/tests/roots/test-bad-config2/index.rst
+++ b/tests/roots/test-bad-config2/index.rst
@@ -1,0 +1,1 @@
+.. drawio-image:: box.drawio

--- a/tests/roots/test-imgconverter/conf.py
+++ b/tests/roots/test-imgconverter/conf.py
@@ -5,3 +5,5 @@ exclude_patterns = ["_build"]
 
 # removes most of the HTML
 html_theme = "basic"
+
+drawio_builder_export_format = {"html": "svg", "latex": "pdf"}

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -5,14 +5,21 @@ import pytest
 
 from bs4 import Tag
 
+# This tests two things:
+# - That it doesn't convert when unnecessary
+# - That it doesn't error.
 
-@pytest.mark.skip(reason="Somehow sphinx doesn't convert the svg to png images.")
+
+@pytest.mark.sphinx("latex", testroot="imgconverter")
+def test_pdfnoconvert(tex_images: List[Path]):
+    (image,) = tex_images
+    # It should not convert a PDF into another format.
+    assert image.basename() == "box.pdf"
+
+
 @pytest.mark.sphinx("html", testroot="imgconverter")
-def test_imgconverter(directives: List[Tag]):
-    (img,) = directives
-    assert img.name == "img"
-    # This will have been converted from our exported
-    # SVG to PNG by sphinx.ext.imgconverter
-    assert img["src"] == "_images/box.png"
-    assert img["alt"] == "_images/box.png"
-    assert img["class"] == ["drawio"]
+def test_noconvert(directives: List[Tag]):
+    # it should not convert an SVG output from sphinx into another format
+    (image,) = directives
+    assert image["src"] == "_images/box.svg"
+    assert image["alt"] == "_images/box.svg"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -115,7 +115,15 @@ def test_bad_config(app_with_local_user_config):
     with pytest.raises(DrawIOError) as exc:
         app_with_local_user_config.build()
     (message,) = exc.value.args
-    assert message == "Invalid export format 'bmp' specified for builder 'html'"
+    assert message == "export format 'bmp' is unsupported by draw.io"
+
+
+@pytest.mark.sphinx("html", testroot="bad-config2")
+def test_bad_config2(app_with_local_user_config):
+    with pytest.raises(DrawIOError) as exc:
+        app_with_local_user_config.build()
+    (message,) = exc.value.args
+    assert message == "invalid export format 'pdf' specified for builder 'html'"
 
 
 @pytest.mark.sphinx("html", testroot="page-name-not-exist")


### PR DESCRIPTION
Fixes #63

Error on invalid formats for both global & local config, for the drawio valid formats and valid builder formats.

Changes imgconverter tests to verify no unnecessary conversions and no erroring when using that extension.