### PR TITLE
Add drawio_disable_gpu config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ conflict. This option only affects the output when the drawio app errors. See th
 [Electron docs](https://www.electronjs.org/docs/latest/api/command-line-switches#--enable-loggingfile)
 for more info.
 
+### Disable GPU
+- *Formal Name*: `drawio_disable_gpu`
+- *Default Value*: `False`
+- *Possible Values*: `True` or `False`
+
+By default, Chrome (Electron) uses GPU processes which can cause errors when
+running in environments that are not set up for it. This option disables those
+GPU processes and uses the CPU instead.
+
 ### No Sandbox
 - *Formal Name*: `drawio_no_sandbox`
 - *Default Value*: `False`

--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -237,6 +237,7 @@ class DrawIOConverter(ImageConverter):
             "transparency", builder.config.drawio_default_transparency
         )
         disable_verbose_electron = builder.config.drawio_disable_verbose_electron
+        disable_gpu = builder.config.drawio_disable_gpu
         no_sandbox = builder.config.drawio_no_sandbox
 
         # Any directive options which would change the output file would go here
@@ -319,6 +320,11 @@ class DrawIOConverter(ImageConverter):
 
         if not disable_verbose_electron:
             drawio_args.append("--enable-logging")
+
+        if disable_gpu:
+            drawio_args.append("--disable-gpu")
+            drawio_args.append("--disable-software-rasterizer")
+            drawio_args.append("--disable-features=DefaultPassthroughCommandDecoder")
 
         if no_sandbox:
             # This may be needed for docker support, and it has to be the last argument to work.
@@ -418,6 +424,9 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     # noinspection PyTypeChecker
     app.add_config_value(
         "drawio_disable_verbose_electron", False, "html", ENUM(True, False)
+    )
+    app.add_config_value(
+        "drawio_disable_gpu", False, "html", ENUM(True, False)
     )
     app.add_config_value("drawio_no_sandbox", False, "html", ENUM(True, False))
 


### PR DESCRIPTION
When running in Docker (or environments not set up for GPU usage in general) you can get errors related to GPU processes. The `drawio_disable_gpu` config option allows those GPU processes to be turned off so that the extension doesn't throw errors.

- Enable `-disable-gpu` and `--disable-software-rasterizer`
  - Fixes `WARNING:sandbox_linux.cc(380)] InitializeSandbox() called with multiple threads in process gpu-process.`
  - Fixes `ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.`
- Enable `--disable-features=DefaultPassthroughCommandDecoder`
  - Fixes `ERROR:gpu_init.cc(521)] Passthrough is not supported, GL is disabled, ANGLE is`