### PR TITLE
Fix deprecated sphinx.testing.path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from pathlib import Path
 from typing import List
@@ -7,7 +6,6 @@ from typing import List
 import pytest
 from bs4 import BeautifulSoup, Tag
 from sphinx.application import Sphinx
-from sphinx.testing.path import path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -55,7 +53,7 @@ def _setup_local_user_config(app):
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "roots"
+    return Path(__file__).parent.abspath() / "roots"
 
 
 @pytest.fixture()


### PR DESCRIPTION
Getting the following in CI:
```
tests/conftest.py:10
  /home/runner/work/sphinxcontrib-drawio/sphinxcontrib-drawio/tests/conftest.py:10: RemovedInSphinx90Warning: 'sphinx.testing.path' is deprecated. Use 'os.path' or 'pathlib' instead.
    from sphinx.testing.path import path
```