### PR TITLE
Restore support for multiple versions of Sphinx

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import sphinx
 from pathlib import Path
 from typing import List
 
@@ -54,7 +55,12 @@ def _setup_local_user_config(app):
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return Path(__file__).parent.absolute() / "roots"
+    if sphinx.version_info[:2] < (7, 2):
+        from sphinx.testing.path import path
+
+        return path(__file__).parent.abspath() / "roots"
+
+    return Path(__file__).resolve().parent / "roots"
 
 
 @pytest.fixture()


### PR DESCRIPTION
Multi-version path fix using inspiration from a core extension: https://github.com/sphinx-doc/sphinxcontrib-applehelp/blob/41c0826f461d295b967c60b8c54643cf78d9479f/tests/conftest.py