### PR TITLE
More multi-version Sphinx path support

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
+import sphinx
 
 from sphinx.application import Sphinx
 
@@ -13,7 +14,10 @@ def test_image_latex_then_html(
     content: Sphinx, tex_images: List[Path], make_app_with_local_user_config
 ):
     box_pdf = tex_images[0]
-    assert box_pdf.basename() == "box.pdf"
+    if sphinx.version_info[:2] < (7, 2):
+        assert box_pdf.basename() == "box.pdf"
+    else:
+        assert box_pdf.name == "box.pdf"
     assert box_pdf.exists()
     html_app = make_app_with_local_user_config(srcdir=content.srcdir)
     html_app.build()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
+import sphinx
 
 from bs4 import Tag
 
@@ -14,7 +15,10 @@ from bs4 import Tag
 def test_pdfnoconvert(tex_images: List[Path]):
     (image,) = tex_images
     # It should not convert a PDF into another format.
-    assert image.basename() == "box.pdf"
+    if sphinx.version_info[:2] < (7, 2):
+        assert image.basename() == "box.pdf"
+    else:
+        assert image.name == "box.pdf"
 
 
 @pytest.mark.sphinx("html", testroot="imgconverter")

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,4 +1,5 @@
 import re
+import sphinx
 from pathlib import Path
 from typing import List
 
@@ -8,7 +9,10 @@ import pytest
 @pytest.mark.sphinx("latex", testroot="image", srcdir="pdf_image")
 def test_pdf_image(tex_images: List[Path]):
     (image,) = tex_images
-    assert image.basename() == "box.pdf"
+    if sphinx.version_info[:2] < (7, 2):
+        assert image.basename() == "box.pdf"
+    else:
+        assert image.name == "box.pdf"
 
 
 @pytest.mark.sphinx("latex", testroot="image", srcdir="pdf_image_crop")


### PR DESCRIPTION
Use `Path.name` instead of `path.basename` only on newer versions of Sphinx testing.