### PR TITLE
Use release/v1 of gh-action-pypi-publish

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -74,7 +74,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
To fix the publish step warning:
```
Warning:  You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.
```
Per the docs: https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-

It also looks like using user/pass is deprecated and needs to switch using a token at some point:
```
Warning: Input 'user' has been deprecated with message: UNSUPPORTED GITHUB ACTION VERSION
Warning: Input 'password' has been deprecated with message: UNSUPPORTED GITHUB ACTION VERSION
```
Docs: https://github.com/pypa/gh-action-pypi-publish#trusted-publishing