### PR TITLE
Fix action events for tagging releases

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,9 +8,6 @@ on:
       - '*'
     tags:
       - '*'
-  create:
-    tags:
-      - '*'
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,7 +52,7 @@ jobs:
   pypi-release:
     needs: test-extension
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'refs/tags/') && github.repository_owner	== 'Modelmat'
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && github.repository_owner == 'Modelmat'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This should fix https://github.com/modelmat/sphinxcontrib-drawio/issues/73

I don't think the [create](https://github.com/modelmat/sphinxcontrib-drawio/actions?query=event%3Acreate) event trigger is actually being used and it seems you can rely on just the [push](https://github.com/modelmat/sphinxcontrib-drawio/actions?query=event%3Apush) event trigger.

I also added a check for the push `event` as an extra precaution for any future changes, per the docs:
> A common use case is to upload packages only on a tagged commit, to do so add a filter to the job:
>
>     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

source: https://github.com/marketplace/actions/pypi-publish

If desired, I could revert the commit that removes the `create` event trigger, as the `push` event check is in place.