### PR TITLE
Only copy files on html builder formats

### DIFF
--- a/sphinxcontrib/drawio/__init__.py
+++ b/sphinxcontrib/drawio/__init__.py
@@ -401,7 +401,7 @@ def on_config_inited(app: Sphinx, config: Config) -> None:
 
 
 def on_build_finished(app: Sphinx, exc: Exception) -> None:
-    if exc is None:
+    if app.builder.format == 'html' and exc is None:
         this_file_path = os.path.dirname(os.path.realpath(__file__))
         src = os.path.join(this_file_path, "drawio.css")
         dst = os.path.join(app.outdir, "_static")


### PR DESCRIPTION
When running builders that have a non-html format, the supporting files (css, etc) are still copied over even though they aren't necessary. This change keeps the non-html builder output clean.